### PR TITLE
fix(editor): avoid id collisions on similar names

### DIFF
--- a/editor/windows/ResourcesWindow.zig
+++ b/editor/windows/ResourcesWindow.zig
@@ -58,7 +58,7 @@ const ItemResult = union(enum) {
 };
 
 const OrderedItem = struct {
-    key: []const u8,
+    key: [:0]const u8,
     res: *ResourceNode,
     type: Resources.Resource.Type,
 
@@ -164,7 +164,7 @@ pub fn draw(self: *Self) !void {
 
 fn drawItem(
     self: *Self,
-    key: []const u8,
+    key: [:0]const u8,
     node: *const Node,
     typ: RType,
     item_sz: f32,
@@ -201,7 +201,7 @@ fn drawItem(
     defer allocator.free(name);
     const is_selected = if (self.selected_file) |sel| sel.eql(node) else false;
     const is_renaming = self.state.isRenaming(node);
-    c.ImGui_PushID(name.ptr);
+    c.ImGui_PushID(key);
     const pos = c.ImGui_GetCursorPos();
     const wrap_width = item_sz;
     const text_size = c.ImGui_CalcTextSizeEx(name.ptr, null, false, wrap_width);

--- a/engine/collections.zig
+++ b/engine/collections.zig
@@ -21,6 +21,15 @@ pub fn ArrayHashMapStringSentinelContext(comptime sentinel: u8) type {
     };
 }
 
+pub const ArrayHashMapStringAdaptedContext = struct {
+    pub fn hash(s: []const u8) u32 {
+        return @as(u32, @truncate(std.hash.Wyhash.hash(0, s)));
+    }
+    pub fn eql(a: []const u8, b: []const u8, _: usize) bool {
+        return std.mem.eql(u8, a, b);
+    }
+};
+
 pub fn ArrayHashMapStringSentinelSortContext(comptime sentinel: u8) type {
     return struct {
         keys: [][:sentinel]const u8,
@@ -40,3 +49,12 @@ pub fn HashMapStringSentinelContext(comptime sentinel: u8) type {
         }
     };
 }
+
+pub const HashMapStringAdaptedContext = struct {
+    pub fn hash(s: []const u8) u64 {
+        return std.hash.Wyhash.hash(0, s);
+    }
+    pub fn eql(a: []const u8, b: []const u8) bool {
+        return std.mem.eql(u8, a, b);
+    }
+};


### PR DESCRIPTION
Resource window now uses the key as IDs instead of display name