### PR TITLE
fix(editor): UI touch ups

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -117,6 +117,10 @@ pub fn build(b: *std.Build) !void {
     editor.linkLibCpp();
     editor.root_module.addImport("yume", yume);
 
+    editor.root_module.addAnonymousImport("THIRD-PARTY-LICENSE", .{
+        .root_source_file = b.path("THIRD-PARTY-LICENSE"),
+    });
+
     b.installArtifact(editor);
     if (target.result.os.tag == .windows) {
         b.installBinFile("vendor/sdl3/lib/SDL3.dll", "SDL3.dll");

--- a/editor/Editor.zig
+++ b/editor/Editor.zig
@@ -42,9 +42,10 @@ const Mat4 = @import("yume").math3d.Mat4;
 const GAL = @import("yume").GAL;
 const check_vk = GAL.RenderApi.check_vk;
 
-const NewProjectModal = @import("NewProjectModal.zig");
-const OpenProjectModal = @import("OpenProjectModal.zig");
-const HelloModal = @import("HelloModal.zig");
+const NewProjectModal = @import("modals/NewProjectModal.zig");
+const OpenProjectModal = @import("modals/OpenProjectModal.zig");
+const HelloModal = @import("modals/HelloModal.zig");
+const AboutModal = @import("modals/AboutModal.zig");
 
 const styles = @import("styles.zig");
 
@@ -128,6 +129,7 @@ dockspace_flags: c.ImGuiDockNodeFlags = 0,
 editors: Editors,
 
 hello_modal: HelloModal,
+about_modal: AboutModal,
 new_project_modal: NewProjectModal,
 open_project_modal: OpenProjectModal,
 
@@ -171,6 +173,7 @@ pub fn init(ctx: *GameApp) !*Self {
         .ctx = ctx,
         .editors = Editors.init(ctx.allocator),
         .hello_modal = try HelloModal.init(),
+        .about_modal = try AboutModal.init(ctx.allocator),
         .new_project_modal = try NewProjectModal.init(ctx.allocator),
         .open_project_modal = try OpenProjectModal.init(ctx.allocator),
         .hierarchy_window = HierarchyWindow.init(ctx.allocator),
@@ -223,6 +226,7 @@ pub fn init(ctx: *GameApp) !*Self {
 pub fn deinit(self: *Self) void {
     self.editors.deinit();
     self.hello_modal.deinit();
+    self.about_modal.deinit();
     self.new_project_modal.deinit();
     self.open_project_modal.deinit();
     self.game_window.deinit();
@@ -389,7 +393,9 @@ pub fn draw(self: *Self) !void {
         if (c.ImGui_BeginMenu("Help")) {
             _ = c.ImGui_MenuItemBoolPtr("ImGui Demo Window", null, &self.imgui_demo_open, true);
             c.ImGui_Separator();
-            if (c.ImGui_MenuItem("About*")) {}
+            if (c.ImGui_MenuItem("About")) {
+                self.about_modal.open();
+            }
             c.ImGui_EndMenu();
         }
         c.ImGui_SetCursorPosX(
@@ -443,9 +449,10 @@ pub fn draw(self: *Self) !void {
     self.game_window.draw(cmd, self.ctx);
     try self.logs_windows.draw();
 
-    self.hello_modal.show();
-    try self.new_project_modal.show(self.ctx);
-    try self.open_project_modal.show(self.ctx);
+    self.hello_modal.draw();
+    try self.about_modal.draw();
+    try self.new_project_modal.draw(self.ctx);
+    try self.open_project_modal.draw(self.ctx);
 
     imutils.render();
 

--- a/editor/imutils.zig
+++ b/editor/imutils.zig
@@ -172,6 +172,17 @@ pub fn buttonCenteredOnLine(label: [*c]const u8, alignment: f32) bool {
     return c.ImGui_Button(label);
 }
 
+pub fn textAlignedHorizontal(text: [*c]const u8, alignment: f32) void {
+    const text_width = c.ImGui_CalcTextSize(text).x;
+    alignHorizontal(text_width, alignment);
+    c.ImGui_Text(text);
+}
+pub fn textLinkAlignedHorizontal(text: [*c]const u8, alignment: f32) bool {
+    const text_width = c.ImGui_CalcTextSize(text).x;
+    alignHorizontal(text_width, alignment);
+    return c.ImGui_TextLink(text);
+}
+
 pub fn collapsingHeaderWithCheckBox(label: [*c]const u8, checked: [*c]bool, flags: c.ImGuiTreeNodeFlags) bool {
     c.ImGui_PushID(label);
     defer c.ImGui_PopID();

--- a/editor/modals/AboutModal.zig
+++ b/editor/modals/AboutModal.zig
@@ -1,0 +1,104 @@
+const c = @import("clibs");
+
+const builtin = @import("builtin");
+const std = @import("std");
+
+const utils = @import("yume").utils;
+
+const Project = @import("../Project.zig");
+
+const imutils = @import("../imutils.zig");
+const Editor = @import("../Editor.zig");
+
+const Self = @This();
+
+const THIRD_PARTY_LICENSES = @embedFile("THIRD-PARTY-LICENSE");
+
+var version_buf: [128]u8 = undefined;
+var version_text: [:0]const u8 = undefined;
+var formatVersionText = std.once(struct {
+    fn f() void {
+        const v = @import("yume").version;
+        version_text = std.fmt.bufPrintZ(
+            &version_buf,
+            "Version {d}.{d}.{d}",
+            .{ v.major, v.minor, v.patch },
+        ) catch @panic("Failed to format version text");
+    }
+}.f);
+
+id: c.ImGuiID = undefined,
+is_open: bool = false,
+allocator: std.mem.Allocator,
+
+pub fn init(allocator: std.mem.Allocator) !Self {
+    formatVersionText.call();
+    return Self{ .allocator = allocator };
+}
+
+pub fn deinit(_: *Self) void {}
+
+pub fn open(self: *Self) void {
+    self.is_open = true;
+}
+
+pub fn close(self: *Self) void {
+    self.is_open = false;
+}
+
+pub fn draw(self: *Self) !void {
+    if (!self.is_open) return;
+    c.ImGui_PushID("about-modal");
+    defer c.ImGui_PopID();
+
+    const viewport = c.ImGui_GetMainViewport();
+    c.ImGui_SetNextWindowPos(.{
+        .x = @max(1, (viewport.*.Size.x - 700) / 2),
+        .y = @max(1, (viewport.*.Size.y - 450) / 2),
+    }, c.ImGuiCond_Appearing);
+    c.ImGui_SetNextWindowSize(.{ .x = 700, .y = 450 }, c.ImGuiCond_Appearing);
+
+    const title = "About";
+    const flags = c.ImGuiWindowFlags_NoDocking | c.ImGuiWindowFlags_NoCollapse | c.ImGuiWindowFlags_NoSavedSettings;
+    self.id = c.ImGui_GetID(title);
+    _ = c.ImGui_Begin(title, &self.is_open, flags);
+    defer c.ImGui_End();
+    if (self.is_open) {
+        const window_size = c.ImGui_GetWindowSize();
+
+        imutils.alignHorizontal(window_size.x, 0.5);
+        c.ImGui_BeginGroup();
+        defer c.ImGui_EndGroup();
+
+        c.ImGui_NewLine();
+        imutils.alignHorizontal(123, 0.5);
+        c.ImGui_Image(Editor.yume_logo_ds, c.ImVec2{ .x = 123, .y = 163 });
+        c.ImGui_PushFont(Editor.ubuntu32);
+        defer c.ImGui_PopFont();
+        c.ImGui_NewLine();
+        imutils.textAlignedHorizontal("Yume", 0.5);
+
+        c.ImGui_PushFont(Editor.ubuntu14);
+        defer c.ImGui_PopFont();
+        imutils.textAlignedHorizontal(version_text, 0.5);
+
+        if (imutils.textLinkAlignedHorizontal("GitHub", 0.5)) {
+            try utils.tryOpenWithOsDefaultApplication(self.allocator, "https://github.com/rzvxa/yume");
+        }
+        if (imutils.textLinkAlignedHorizontal("Yume itself is licensed under MIT", 0.5)) {
+            try utils.tryOpenWithOsDefaultApplication(self.allocator, "https://github.com/rzvxa/yume/blob/main/LICENSE");
+        }
+
+        imutils.textAlignedHorizontal("Third-Party licenses(let us know if anything is missing here)", 0.5);
+
+        _ = c.ImGui_InputTextMultilineEx(
+            "##third-party-licenses",
+            @constCast(THIRD_PARTY_LICENSES.ptr),
+            THIRD_PARTY_LICENSES.len + 1,
+            .{ .x = window_size.x, .y = c.ImGui_GetContentRegionAvail().y },
+            c.ImGuiInputTextFlags_ReadOnly,
+            null,
+            null,
+        );
+    }
+}

--- a/editor/modals/HelloModal.zig
+++ b/editor/modals/HelloModal.zig
@@ -3,11 +3,12 @@ const c = @import("clibs");
 const builtin = @import("builtin");
 const std = @import("std");
 
-const Project = @import("Project.zig");
-
-const imutils = @import("imutils.zig");
-const Editor = @import("Editor.zig");
 const utils = @import("yume").utils;
+
+const Project = @import("../Project.zig");
+
+const imutils = @import("../imutils.zig");
+const Editor = @import("../Editor.zig");
 
 const Self = @This();
 
@@ -35,7 +36,7 @@ pub fn close(self: *Self) void {
     self.is_open = false;
 }
 
-pub fn show(self: *Self) void {
+pub fn draw(self: *Self) void {
     if (Project.current() != null) return;
     c.ImGui_PushID("hello-modal");
     defer c.ImGui_PopID();
@@ -51,18 +52,20 @@ pub fn show(self: *Self) void {
 
         imutils.alignHorizontal(700, 0.5);
         c.ImGui_BeginGroup();
+        defer c.ImGui_EndGroup();
 
         c.ImGui_SetCursorPosY(c.ImGui_GetCursorPosY() + box_height / 4);
         imutils.alignHorizontal(700, 0.5);
         c.ImGui_Image(Editor.yume_logo_ds, c.ImVec2{ .x = 246, .y = 326 });
         c.ImGui_PushFont(Editor.ubuntu32);
+        defer c.ImGui_PopFont();
         c.ImGui_NewLine();
         imutils.alignHorizontal(730, 0.5);
         const version = @import("yume").version;
         c.ImGui_Text("Welcome to Yume v%d.%d.%d", version.major, version.minor, version.patch);
-        c.ImGui_PopFont();
         for (0..1) |_| c.ImGui_Spacing();
         c.ImGui_PushFont(Editor.ubuntu24);
+        defer c.ImGui_PopFont();
         imutils.alignHorizontal(875, 0.5);
         if (c.ImGui_Button("\t\tNew Project\t\t")) {
             Editor.instance().newProject();
@@ -74,9 +77,6 @@ pub fn show(self: *Self) void {
         c.ImGui_NewLine();
         imutils.alignHorizontal(550, 0.5);
         c.ImGui_Text("Recent:");
-        c.ImGui_PopFont();
-        c.ImGui_EndGroup();
-
-        c.ImGui_End();
     }
+    c.ImGui_End();
 }

--- a/editor/modals/NewProjectModal.zig
+++ b/editor/modals/NewProjectModal.zig
@@ -18,11 +18,11 @@ const Vec3 = @import("yume").Vec3;
 const Mat4 = @import("yume").Mat4;
 const utils = @import("yume").utils;
 
-const imutils = @import("imutils.zig");
-const Editor = @import("Editor.zig");
-const Project = @import("Project.zig");
-const Resources = @import("Resources.zig");
-const EditorDatabase = @import("EditorDatabase.zig");
+const imutils = @import("../imutils.zig");
+const Editor = @import("../Editor.zig");
+const Project = @import("../Project.zig");
+const Resources = @import("../Resources.zig");
+const EditorDatabase = @import("../EditorDatabase.zig");
 
 const Self = @This();
 
@@ -67,7 +67,7 @@ pub fn close(self: *Self) void {
     self.is_open = false;
 }
 
-pub fn show(self: *Self, ctx: *GameApp) !void {
+pub fn draw(self: *Self, ctx: *GameApp) !void {
     if (!self.is_open) return;
     c.ImGui_PushID("new-project-modal");
     defer c.ImGui_PopID();

--- a/editor/modals/OpenProjectModal.zig
+++ b/editor/modals/OpenProjectModal.zig
@@ -4,6 +4,7 @@ const builtin = @import("builtin");
 const std = @import("std");
 const log = std.log.scoped(.OpenProjectModal);
 
+const utils = @import("yume").utils;
 const Uuid = @import("yume").Uuid;
 const Scene = @import("yume").scene_graph.Scene;
 
@@ -16,11 +17,10 @@ const MeshRenderer = @import("yume").MeshRenderer;
 const Vec3 = @import("yume").Vec3;
 const Mat4 = @import("yume").Mat4;
 
-const imutils = @import("imutils.zig");
-const Editor = @import("Editor.zig");
-const EditorDatabase = @import("EditorDatabase.zig");
-const Project = @import("Project.zig");
-const utils = @import("yume").utils;
+const imutils = @import("../imutils.zig");
+const Editor = @import("../Editor.zig");
+const EditorDatabase = @import("../EditorDatabase.zig");
+const Project = @import("../Project.zig");
 
 const Self = @This();
 
@@ -67,7 +67,7 @@ pub fn close(self: *Self) void {
     self.is_open = false;
 }
 
-pub fn show(self: *Self, ctx: *GameApp) !void {
+pub fn draw(self: *Self, ctx: *GameApp) !void {
     if (!self.is_open) return;
     c.ImGui_PushID("open-project-modal");
     defer c.ImGui_PopID();

--- a/editor/windows/ProjectExplorerWindow.zig
+++ b/editor/windows/ProjectExplorerWindow.zig
@@ -1030,8 +1030,22 @@ pub const Filter = struct {
 };
 
 pub fn filterByResourceType(ty: Resources.Resource.Type) Filter {
+    const tag_name: [:0]const u8 = switch (ty) {
+        .unknown => "Unknown File Type",
+        .project => "Project File",
+        .scene => ".scene",
+        .shader_stage => ".frag/.vert",
+        .shader => ".shader",
+        .mat => ".mat",
+        .obj => ".obj",
+        .fbx => ".fbx",
+        .png => ".png",
+    };
+
     return .{
-        .tag_name = .{ .constant = @tagName(ty) },
+        .tag_name = .{
+            .constant = tag_name,
+        },
         .predicate = &struct {
             fn pred(f: *const Filter, it: *const Entry) bool {
                 return switch (it.kind) {


### PR DESCRIPTION
cleanups some UIs, moves all modals to a single directory, and adds a simple about page containing all the third-party licenses found in the [THIRD-PARTY-LICENSE](https://github.com/rzvxa/yume/blob/main/THIRD-PARTY-LICENSE)

![{95E6089B-31E9-4CC4-A3CA-D0A35529B80D}](https://github.com/user-attachments/assets/052eb128-ae27-4936-ba8f-c87ef2e714fa)
